### PR TITLE
Fixed issue with string comparision for sandbox

### DIFF
--- a/src/main/java/com/twocheckout/TwocheckoutApi.java
+++ b/src/main/java/com/twocheckout/TwocheckoutApi.java
@@ -31,12 +31,9 @@ public abstract class TwocheckoutApi {
         ArrayList<NameValuePair> params = TwocheckoutUtil.convert(args);
         String apiusername = Twocheckout.apiusername;
         String apipassword = Twocheckout.apipassword;
-        String url;
-        if (Twocheckout.mode == "sandbox" ) {
-            url = Twocheckout.sandboxBaseURL+urlSuffix;
-        } else {
-            url = Twocheckout.baseURL+urlSuffix;
-        }
+        String url = "sandbox".equals(Twocheckout.mode)
+            ? Twocheckout.sandboxBaseURL + urlSuffix
+            : Twocheckout.baseURL + urlSuffix;
         url = addLocationToUrl(url, params);
         String mainObject = null;
         
@@ -73,12 +70,9 @@ public abstract class TwocheckoutApi {
         ArrayList<NameValuePair> params = TwocheckoutUtil.convert(args);
         String apiusername = Twocheckout.apiusername;
         String apipassword = Twocheckout.apipassword;
-        String url;
-        if (Twocheckout.mode == "sandbox" ) {
-            url = Twocheckout.sandboxBaseURL+urlSuffix;
-        } else {
-            url = Twocheckout.baseURL+urlSuffix;
-        }
+        String url = "sandbox".equals(Twocheckout.mode)
+            ? Twocheckout.sandboxBaseURL+urlSuffix
+            : Twocheckout.baseURL+urlSuffix;
         String mainObject = null;
            URI uri;
         try {
@@ -113,12 +107,9 @@ public abstract class TwocheckoutApi {
     public static String auth(String urlSuffix, HashMap<String, Object> args) throws TwocheckoutException {
         args.put("privateKey", Twocheckout.privatekey);
         String request = new Gson().toJson(args);
-        String url;
-        if (Twocheckout.mode == "sandbox" ) {
-            url = Twocheckout.sandboxBaseURL+urlSuffix;
-        } else {
-            url = Twocheckout.baseURL+urlSuffix;
-        }
+        String url = "sandbox".equals(Twocheckout.mode)
+            ? Twocheckout.sandboxBaseURL+urlSuffix
+            : Twocheckout.baseURL+urlSuffix;
         String mainObject = null;
         URI uri;
         try {


### PR DESCRIPTION
I added this fix in order to avoid issues when comparing string.

Specifically in my project I had the next issue:
1. **I have a** HashMap<String, String> props = new HashMap<>();
2. **I added a mode property** props.put("mode", "sandbox");
3. **Set the** Twocheckout.mode = props.get("mode");

The issue:
In the TwocheckoutAPI.java The comparision:
Twocheckout.mode == "sandbox" **is false**.

I fixed this issue in this PR.
