### PR TITLE
Update TwocheckoutApi.java

### DIFF
--- a/src/main/java/com/twocheckout/TwocheckoutApi.java
+++ b/src/main/java/com/twocheckout/TwocheckoutApi.java
@@ -63,8 +63,10 @@ public abstract class TwocheckoutApi {
                 return responseBody;
             }
 
+        } catch (TwocheckoutException e) {
+            throw e;
         } catch (Exception e) {
-            throw new TwocheckoutException(e.getMessage());
+            throw new TwocheckoutException(e.getMessage(),e);
         }
 
         return mainObject;
@@ -102,8 +104,10 @@ public abstract class TwocheckoutApi {
                 return responseBody;
             }
 
+        } catch (TwocheckoutException e) {
+            throw e;
         } catch (Exception e) {
-            throw new TwocheckoutException(e.getMessage());
+            throw new TwocheckoutException(e.getMessage(),e);
         }
 
         return mainObject;
@@ -136,8 +140,10 @@ public abstract class TwocheckoutApi {
                 return responseBody;
             }
 
+        } catch (TwocheckoutException e) {
+            throw e;
         } catch (Exception e) {
-            throw new TwocheckoutException(e.getMessage());
+            throw new TwocheckoutException(e.getMessage(),e);
         }
 
         return mainObject;
@@ -157,7 +163,7 @@ public abstract class TwocheckoutApi {
         if (status.getStatusCode() != HttpStatus.SC_OK) {
             Errors errors = new Gson().fromJson(responseBody, Errors.class);
             Error[] error = errors.getErrors();
-            throw new TwocheckoutException(error[0].getMessage());
+            throw new TwocheckoutException(error[0].getMessage(), error[0]);
         }
     }
 
@@ -166,7 +172,7 @@ public abstract class TwocheckoutApi {
         if (status.getStatusCode() != HttpStatus.SC_OK && status.getStatusCode() != HttpStatus.SC_ACCEPTED ) {
             AuthExceptions exceptions = new Gson().fromJson(responseBody, AuthExceptions.class);
             AuthException exception = exceptions.getAuthExceptions();
-            throw new TwocheckoutException(exception.getMessage());
+            throw new TwocheckoutException(exception.getMessage(),exception);
         }
     }
 


### PR DESCRIPTION
Hi I'm proposing to include the original Exception in TwocheckoutException(), so the caller can get more details (errorCode, HttpStatus) about the Exception by getCause() method

With this I can get the original Exception with more information about the 2Checkout response.
It's very important to me.