### PR TITLE
Support posting of UTF-8 content.

### DIFF
--- a/src/main/java/com/twocheckout/TwocheckoutApi.java
+++ b/src/main/java/com/twocheckout/TwocheckoutApi.java
@@ -127,7 +127,7 @@ public abstract class TwocheckoutApi {
             httppost.setHeader("Accept", "application/json");
             httppost.setHeader("User-Agent", String.format("2Checkout/Java/%s", Twocheckout.VERSION));
             httppost.getParams().setParameter(ClientPNames.COOKIE_POLICY, CookiePolicy.RFC_2109);
-            httppost.setEntity(new StringEntity(request, ContentType.create("application/json")));
+            httppost.setEntity(new StringEntity(request, ContentType.create("application/json", "UTF-8")));
             HttpResponse response = httpclient.execute(httppost);
             HttpEntity entity = response.getEntity();
             String responseBody = EntityUtils.toString(entity);


### PR DESCRIPTION
Default charset for StringEntity is ISO_8859_1 which causes problems when sending Java strings containing non-latin characters (ex. cyrillic texts break which leads to charges being marked as suspicious). "UTF-8" should be explicitly set to ensure posted data is correctly sent.